### PR TITLE
Allow hiding of the battery status bar indicator

### DIFF
--- a/res/values/pa_strings.xml
+++ b/res/values/pa_strings.xml
@@ -113,6 +113,7 @@
     <string name="battery_bar_percent">Bar &amp; percent</string>
     <string name="battery_circle">Circle</string>
     <string name="battery_circle_percent">Circle &amp; percent</string>
+    <string name="battery_hidden">Hidden</string>
 
     <!-- Message of dialog confirming that user wants to restart their device with a new runtime -->
     <string name="custom_runtime_warning_title">Warning</string>

--- a/src/com/android/settings/fuelgauge/PowerUsageSummary.java
+++ b/src/com/android/settings/fuelgauge/PowerUsageSummary.java
@@ -72,7 +72,8 @@ public class PowerUsageSummary extends PreferenceFragment {
     private static final int SUBMENU_BATTERY_BAR_PERCENT    = Menu.FIRST + 10;
     private static final int SUBMENU_BATTERY_CIRCLE         = Menu.FIRST + 11;
     private static final int SUBMENU_BATTERY_CIRCLE_PERCENT = Menu.FIRST + 12;
-    private static final int MENU_HELP                      = Menu.FIRST + 13;
+    private static final int SUBMENU_BATTERY_HIDDEN         = Menu.FIRST + 13;
+    private static final int MENU_HELP                      = Menu.FIRST + 14;
 
     private PreferenceGroup mAppListGroup;
     private Preference mBatteryStatusPref;
@@ -206,6 +207,8 @@ public class PowerUsageSummary extends PreferenceFragment {
                     .setChecked(selectedIcon == 2);
         batteryStyle.add(1, SUBMENU_BATTERY_CIRCLE_PERCENT, 4, R.string.battery_circle_percent)
                     .setChecked(selectedIcon == 3);
+        batteryStyle.add(1, SUBMENU_BATTERY_HIDDEN, 5, R.string.battery_hidden)
+                    .setChecked(selectedIcon == 4);
         batteryStyle.setGroupCheckable(1, true, true);
 
         MenuItem warningIcon = batteryWarning.getItem();
@@ -282,6 +285,11 @@ public class PowerUsageSummary extends PreferenceFragment {
                 item.setChecked(true);
                 Settings.System.putInt(getActivity().getContentResolver(),
                     Settings.System.STATUS_BAR_BATTERY_STYLE, 3);
+                return true;
+            case SUBMENU_BATTERY_HIDDEN:
+                item.setChecked(true);
+                Settings.System.putInt(getActivity().getContentResolver(),
+                    Settings.System.STATUS_BAR_BATTERY_STYLE, 4);
                 return true;
             default:
                 return false;


### PR DESCRIPTION
This commit simply adds a special value for a hidden status bar
indicator. This works due to the fact that the existing indicators
check that the current value matches their one which means that if
no indicators will be visible if no matches are found. This is usable
by people who like minimalistic aproaches and also assists people who
modify their systems to add some special battery indicators that are
no provided by the default system (as otherwise they would end up with
two indicators side-by-side).

It should still be noted that without changes in the system UI the QS
tile for battery looks a bit weird when this is applied as the battery
indicator disappears from there as well.

Change-Id: Ie23382817e00a4a9a13115cba2db789d038910a7
