### PR TITLE
Expose hardcoded and @android colors from layouts

### DIFF
--- a/res/layout-land/choose_lock_password.xml
+++ b/res/layout-land/choose_lock_password.xml
@@ -62,7 +62,7 @@
         android:layout_alignParentBottom="true"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="#00000000"
+        android:background="@color/background_color_transparent"
         android:keyBackground="@*android:drawable/btn_keyboard_key_fulltrans"
         android:visibility="gone"
     />

--- a/res/layout-land/confirm_lock_password.xml
+++ b/res/layout-land/confirm_lock_password.xml
@@ -69,7 +69,7 @@
         android:layout_alignParentBottom="true"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="#00000000"
+        android:background="@color/background_color_transparent"
         android:keyBackground="@*android:drawable/btn_keyboard_key_fulltrans"
         android:visibility="gone"
     />

--- a/res/layout-land/setup_preference.xml
+++ b/res/layout-land/setup_preference.xml
@@ -51,7 +51,7 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        android:cacheColorHint="@android:color/transparent"
+        android:cacheColorHint="@color/background_color_transparent"
         android:clipToPadding="false"
         android:drawSelectorOnTop="false"
         android:headerDividersEnabled="false"

--- a/res/layout-sw600dp-land/choose_lock_password.xml
+++ b/res/layout-sw600dp-land/choose_lock_password.xml
@@ -82,7 +82,7 @@
         android:layout_alignParentBottom="true"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="#00000000"
+        android:background="@color/background_color_transparent"
         android:keyBackground="@*android:drawable/btn_keyboard_key_fulltrans"
         android:visibility="gone"
     />

--- a/res/layout-sw600dp-land/confirm_lock_password.xml
+++ b/res/layout-sw600dp-land/confirm_lock_password.xml
@@ -83,7 +83,7 @@
         android:layout_alignParentBottom="true"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="#00000000"
+        android:background="@color/background_color_transparent"
         android:keyBackground="@*android:drawable/btn_keyboard_key_fulltrans"
         android:visibility="gone"
     />

--- a/res/layout-sw600dp-land/setup_preference.xml
+++ b/res/layout-sw600dp-land/setup_preference.xml
@@ -66,7 +66,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="0dp"
                     android:layout_weight="1"
-                    android:cacheColorHint="@android:color/transparent"
+                    android:cacheColorHint="@color/background_color_transparent"
                     android:clipToPadding="false"
                     android:drawSelectorOnTop="false"
                     android:headerDividersEnabled="false"

--- a/res/layout-sw600dp/choose_lock_password.xml
+++ b/res/layout-sw600dp/choose_lock_password.xml
@@ -56,7 +56,7 @@
         android:layout_alignParentBottom="true"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="#00000000"
+        android:background="@color/background_color_transparent"
         android:layout_marginBottom="30dip"
         android:keyBackground="@*android:drawable/btn_keyboard_key_fulltrans"
         android:visibility="gone"

--- a/res/layout-sw600dp/confirm_lock_password.xml
+++ b/res/layout-sw600dp/confirm_lock_password.xml
@@ -67,7 +67,7 @@
         android:layout_alignParentBottom="true"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="#00000000"
+        android:background="@color/background_color_transparent"
         android:layout_marginBottom="30dip"
         android:keyBackground="@*android:drawable/btn_keyboard_key_fulltrans"
         android:visibility="gone"

--- a/res/layout-sw600dp/setup_preference.xml
+++ b/res/layout-sw600dp/setup_preference.xml
@@ -65,7 +65,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="0dp"
                     android:layout_weight="1"
-                    android:cacheColorHint="@android:color/transparent"
+                    android:cacheColorHint="@color/background_color_transparent"
                     android:clipToPadding="false"
                     android:drawSelectorOnTop="false"
                     android:headerDividersEnabled="false"

--- a/res/layout/battery_history_chart.xml
+++ b/res/layout/battery_history_chart.xml
@@ -28,7 +28,7 @@
         android:gravity="center_vertical"
         android:id="@+id/battery_history_chart"
         android:textAppearance="?android:attr/textAppearanceSmall"
-        android:textColor="#ff000000"
+        android:textColor="@color/text_color_black"
         app:headerAppearance="?android:attr/textAppearanceMedium"
         android:shadowRadius="4"
         android:shadowColor="?android:attr/colorBackground"

--- a/res/layout/bluetooth_pin_confirm.xml
+++ b/res/layout/bluetooth_pin_confirm.xml
@@ -38,7 +38,7 @@
             android:layout_marginTop="@dimen/bluetooth_dialog_padding"
             android:gravity="center_vertical"
             android:textAppearance="@android:style/TextAppearance.Material.Body1"
-            android:textColor="@*android:color/secondary_text_material_light"  />
+            android:textColor="@color/text_color_secondary_text_material_light"  />
 
         <TextView
             android:id="@+id/message_subhead"
@@ -60,7 +60,7 @@
             android:text="@string/bluetooth_pairing_key_msg"
             android:visibility="gone"
             android:textAppearance="@android:style/TextAppearance.Material.Body1"
-            android:textColor="@*android:color/secondary_text_material_light"  />
+            android:textColor="@color/text_color_secondary_text_material_light"  />
 
         <TextView
             android:id="@+id/pairing_subhead"
@@ -83,7 +83,7 @@
             android:gravity="center_vertical"
             android:text="@string/bluetooth_enter_passkey_msg"
             android:textAppearance="@android:style/TextAppearance.Material.Subhead"
-            android:textColor="@*android:color/secondary_text_material_light"
+            android:textColor="@color/text_color_secondary_text_material_light"
             android:visibility="gone" />
 
         <TextView

--- a/res/layout/bluetooth_pin_entry.xml
+++ b/res/layout/bluetooth_pin_entry.xml
@@ -85,7 +85,7 @@
             android:layout_marginEnd="@dimen/bluetooth_dialog_padding"
             android:gravity="center_vertical"
             android:textAppearance="@android:style/TextAppearance.Material.Subhead"
-            android:textColor="@*android:color/secondary_text_material_light"/>
+            android:textColor="@color/text_color_secondary_text_material_light"/>
 
         <TextView
             android:id="@+id/phonebook_sharing_message"

--- a/res/layout/choose_lock_password.xml
+++ b/res/layout/choose_lock_password.xml
@@ -71,7 +71,7 @@
         android:layout_alignParentBottom="true"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="#00000000"
+        android:background="@color/background_color_transparent"
         android:keyBackground="@*android:drawable/btn_keyboard_key_fulltrans"
         android:visibility="gone"
     />

--- a/res/layout/confirm_lock_password.xml
+++ b/res/layout/confirm_lock_password.xml
@@ -57,7 +57,7 @@
         android:layout_alignParentBottom="true"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:background="#00000000"
+        android:background="@color/background_color_transparent"
         android:keyBackground="@*android:drawable/btn_keyboard_key_fulltrans"
         android:visibility="gone"
     />

--- a/res/layout/credentials_disallowed_preference_screen.xml
+++ b/res/layout/credentials_disallowed_preference_screen.xml
@@ -26,8 +26,8 @@
                 android:layout_height="match_parent"
                 android:drawSelectorOnTop="false"
                 android:scrollbarStyle="insideOverlay"
-                android:background="@android:color/white"
-                android:cacheColorHint="@android:color/white"
+                android:background="@color/background_color_white"
+                android:cacheColorHint="@color/background_color_white"
                 android:fadingEdgeLength="16dip" />
 
         <TextView android:id="@android:id/empty"

--- a/res/layout/crypt_keeper_emergency_button.xml
+++ b/res/layout/crypt_keeper_emergency_button.xml
@@ -27,7 +27,7 @@
     android:layout_gravity="center_horizontal"
     android:textSize="14sp"
     android:fontFamily="sans-serif"
-    android:textColor="#FFFFFF"
+    android:textColor="@color/text_color_white"
     android:layout_weight="1"
     android:gravity="bottom"
     style="?android:attr/borderlessButtonStyle" />

--- a/res/layout/crypt_keeper_status.xml
+++ b/res/layout/crypt_keeper_status.xml
@@ -35,7 +35,7 @@
         android:layout_marginEnd="8dip"
         android:textSize="16sp"
         android:fontFamily="sans-serif"
-        android:textColor="@android:color/white"
+        android:textColor="@color/text_color_white"
         android:text="@string/enter_password"
         android:layout_gravity="center_horizontal"
         android:gravity="center_horizontal" />
@@ -52,7 +52,7 @@
         android:marqueeRepeatLimit ="marquee_forever"
         android:textSize="16sp"
         android:fontFamily="sans-serif"
-        android:textColor="#B3FFFFFF"
+        android:textColor="@color/text_color_translucent_white"
         android:gravity="center_horizontal" />
 
 </LinearLayout>

--- a/res/layout/dashboard_category.xml
+++ b/res/layout/dashboard_category.xml
@@ -21,7 +21,7 @@
         android:paddingStart="@dimen/dashboard_category_padding_start"
         android:paddingEnd="@dimen/dashboard_category_padding_end"
         android:orientation="vertical"
-        android:background="@android:color/white"
+        android:background="@color/dashboard_category_background_color"
         android:layout_marginBottom="8dip"
         android:elevation="@dimen/dashboard_category_elevation">
 

--- a/res/layout/data_usage_chart.xml
+++ b/res/layout/data_usage_chart.xml
@@ -42,9 +42,9 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_gravity="start|bottom"
-        settings:strokeColor="#00000000"
-        settings:fillColor="#ff009688"
-        settings:fillColorSecondary="#ff80cbc4"
+        settings:strokeColor="@color/data_usage_stroke_color"
+        settings:fillColor="@color/data_usage_fill_color"
+        settings:fillColorSecondary="@color/data_usage_secondary_fill_color"
         settings:safeRegion="3dp" />
 
     <com.android.settings.widget.ChartNetworkSeriesView
@@ -52,9 +52,9 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:layout_gravity="start|bottom"
-        settings:strokeColor="#00000000"
-        settings:fillColor="#ff009688"
-        settings:fillColorSecondary="#ff009688"
+        settings:strokeColor="@color/data_usage_stroke_color"
+        settings:fillColor="@color/data_usage_fill_color"
+        settings:fillColorSecondary="@color/data_usage_fill_color"
         settings:safeRegion="3dp" />
 
     <com.android.settings.widget.ChartSweepView
@@ -67,7 +67,7 @@
         settings:neighborMargin="5dip"
         settings:labelSize="60dip"
         settings:labelTemplate="@string/data_usage_sweep_warning"
-        settings:labelColor="#ff37474f"
+        settings:labelColor="@color/data_usage_label_color"
         settings:safeRegion="4dp" />
 
     <com.android.settings.widget.ChartSweepView
@@ -80,7 +80,7 @@
         settings:neighborMargin="5dip"
         settings:labelSize="60dip"
         settings:labelTemplate="@string/data_usage_sweep_limit"
-        settings:labelColor="#fff4511e"
+        settings:labelColor="@color/data_usage_secondary_label_color"
         settings:safeRegion="4dp" />
 
 </com.android.settings.widget.ChartDataUsageView>

--- a/res/layout/installed_app_details.xml
+++ b/res/layout/installed_app_details.xml
@@ -420,7 +420,7 @@
                 android:text="@string/permissions_label" />
             <TextView android:id="@+id/security_settings_billing_desc"
                 android:text="@string/security_settings_billing_desc"
-                android:textColor="#ffffb060"
+                android:textColor="@color/security_settings_billing_desc_color"
                 android:textAppearance="?android:attr/textAppearanceSmall"
                 android:paddingTop="6dip"
                 android:paddingBottom="6dip"

--- a/res/layout/keyguard_appwidget_picker_layout.xml
+++ b/res/layout/keyguard_appwidget_picker_layout.xml
@@ -28,6 +28,6 @@
             android:layout_weight="1"
             android:numColumns="@integer/keyguard_appwidget_picker_cols"
             android:layout_gravity="center_horizontal"
-            android:listSelector="@android:color/transparent"
+            android:listSelector="@color/background_color_transparent"
             android:id="@+id/widget_list" />
 </LinearLayout>

--- a/res/layout/master_clear_disallowed_screen.xml
+++ b/res/layout/master_clear_disallowed_screen.xml
@@ -26,8 +26,8 @@
                 android:layout_height="match_parent"
                 android:drawSelectorOnTop="false"
                 android:scrollbarStyle="insideOverlay"
-                android:background="@android:color/white"
-                android:cacheColorHint="@android:color/white"
+                android:background="@color/background_color_white"
+                android:cacheColorHint="@color/background_color_white"
                 android:fadingEdgeLength="16dip" />
 
         <TextView android:id="@android:id/empty"

--- a/res/layout/multi_sim_dialog.xml
+++ b/res/layout/multi_sim_dialog.xml
@@ -59,7 +59,7 @@
                     android:text="@string/sim_editor_carrier" />
 
             <TextView android:id="@+id/carrier"
-                    android:textColor="@android:color/black"
+                    android:textColor="@color/text_color_black"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:paddingBottom="@dimen/sim_dialog_margin_bottom"
@@ -84,7 +84,7 @@
                     android:layout_height="wrap_content"
                     android:paddingBottom="@dimen/sim_dialog_margin_bottom"
                     android:singleLine="true"
-                    android:textColor="@android:color/black"
+                    android:textColor="@color/text_color_black"
                     style="?android:attr/textAppearanceMedium" />
 
         </LinearLayout>

--- a/res/layout/nfc_payment.xml
+++ b/res/layout/nfc_payment.xml
@@ -32,7 +32,7 @@
             android:textSize="20sp"
             android:textStyle="italic"
             android:visibility="gone"
-            android:textColor="@android:color/holo_blue_light"
+            android:textColor="@color/text_color_holo_blue_light"
             android:paddingTop="16dp"
             android:text="@string/nfc_payment_learn_more"/>
     </LinearLayout>

--- a/res/layout/notification_app_list.xml
+++ b/res/layout/notification_app_list.xml
@@ -26,10 +26,10 @@
         android:layout_height="match_parent"
         android:paddingStart="@dimen/settings_side_margin"
         android:paddingEnd="@dimen/settings_side_margin"
-        android:divider="#0000"
+        android:divider="@color/background_color_transparent"
         android:dividerHeight="0px"
         android:fastScrollEnabled="true"
-        android:listSelector="#0000"
+        android:listSelector="@color/background_color_transparent"
         android:scrollbarStyle="outsideInset" />
 
     <TextView

--- a/res/layout/ownerinfo.xml
+++ b/res/layout/ownerinfo.xml
@@ -18,7 +18,7 @@
     android:layout_height="wrap_content"
     android:orientation="vertical"
     android:scrollbars="vertical"
-    android:background="@android:color/white">
+    android:background="@color/background_color_white">
 
     <ScrollView
         android:layout_width="match_parent"
@@ -37,7 +37,7 @@
                 android:paddingTop="53dip"
                 android:layout_width="match_parent"
                 android:layout_height="1dip"
-                android:background="#ff404040"
+                android:background="@color/ownerinfo_divider_color"
                 />
 
             <EditText android:id="@+id/owner_info_nickname"
@@ -62,7 +62,7 @@
             <View
                 android:layout_width="match_parent"
                 android:layout_height="1dip"
-                android:background="#ff404040"
+                android:background="@color/ownerinfo_divider_color"
                 />
 
             <EditText android:id="@+id/owner_info_edit_text"

--- a/res/layout/preference_empty_list.xml
+++ b/res/layout/preference_empty_list.xml
@@ -18,7 +18,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:minHeight="48dip"
-    android:background="@android:color/transparent">
+    android:background="@color/background_color_transparent">
 
     <TextView
         android:id="@+android:id/title"

--- a/res/layout/preference_list_fragment.xml
+++ b/res/layout/preference_list_fragment.xml
@@ -22,7 +22,7 @@
       android:orientation="vertical"
       android:layout_width="match_parent"
       android:layout_height="match_parent"
-      android:background="@android:color/transparent">
+      android:background="@color/background_color_transparent">
 
     <FrameLayout android:id="@+id/pinned_header"
                  android:layout_width="wrap_content"

--- a/res/layout/setup_preference.xml
+++ b/res/layout/setup_preference.xml
@@ -36,7 +36,7 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
-        android:cacheColorHint="@android:color/transparent"
+        android:cacheColorHint="@color/background_color_transparent"
         android:clipToPadding="false"
         android:drawSelectorOnTop="false"
         android:headerDividersEnabled="false"

--- a/res/layout/user_dictionary_add_word.xml
+++ b/res/layout/user_dictionary_add_word.xml
@@ -34,7 +34,7 @@
           android:text="@string/user_dict_settings_add_dialog_title" />
     <View android:layout_width="match_parent"
           android:layout_height="2dip"
-          android:background="@android:color/holo_blue_light" />
+          android:background="@color/background_color_holo_blue_light" />
   </LinearLayout>
 
   <EditText android:id="@+id/user_dictionary_add_word_text"

--- a/res/layout/wifi_assistant_card.xml
+++ b/res/layout/wifi_assistant_card.xml
@@ -16,7 +16,7 @@
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/wifi_assistant_card"
-    android:background="@android:color/transparent"
+    android:background="@color/background_color_transparent"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
     android:gravity="center_vertical"
@@ -49,7 +49,7 @@
 
     <TextView
         android:id="@+id/wifi_assistant_text"
-        android:background="@android:color/transparent"
+        android:background="@color/background_color_transparent"
         android:layout_height="wrap_content"
         android:layout_width="wrap_content"
         android:layout_marginBottom="@dimen/wifi_assistant_padding_top_bottom"
@@ -60,7 +60,7 @@
         android:textAppearance="?android:attr/textAppearanceMedium" />
 
     <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        android:background="@android:color/transparent"
+        android:background="@color/background_color_transparent"
         android:layout_height="wrap_content"
         android:layout_width="fill_parent"
         android:gravity="end"

--- a/res/values/pa_colors.xml
+++ b/res/values/pa_colors.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (C) 2015 The ParanoidAndroid Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+          http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<resources>
+    <!-- Hard coded background and text colors exposed for better theme support -->
+    <color name="background_color_holo_blue_light">@android:color/holo_blue_light</color>
+    <color name="background_color_transparent">@android:color/transparent</color>
+    <color name="background_color_white">@android:color/white</color>
+    <color name="text_color_black">@android:color/black</color>
+    <color name="text_color_holo_blue_light">@android:color/holo_blue_light</color>
+    <color name="text_color_secondary_text_material_light">
+        @*android:color/secondary_text_material_light
+    </color>
+    <color name="text_color_translucent_white">#B3FFFFFF</color>
+    <color name="text_color_white">@android:color/white</color>
+    <!-- Dashboard background color -->
+    <color name="dashboard_category_background_color">@android:color/white</color>
+    <!-- Data usage chart color -->
+    <color name="data_usage_stroke_color">#00000000</color>
+    <color name="data_usage_fill_color">#ff009688</color>
+    <color name="data_usage_secondary_fill_color">#ff80cbc4</color>
+    <color name="data_usage_label_color">#ff37474f</color>
+    <color name="data_usage_secondary_label_color">#fff4511e</color>
+    <!-- Owner info -->
+    <color name="ownerinfo_divider_color">#ff404040</color>
+    <!-- Installed app details -->
+    <color name="security_settings_billing_desc_color">#ffffb060</color>
+</resources>


### PR DESCRIPTION
This will allow theme designers better flexibility with the themes
they design for Settings.  There are probably other resources we
need to expose but this is a good start.

CM commit: http://review.cyanogenmod.org/#/c/87074/
PA changes: Move cm_colors to pa_colors and remove unused values.

Change-Id: I81254f72cd2d47bc05a7f15c8e3a9fb4c89c8be8
Signed-off-by: Evan Anderson evananderson@aospa.co
