### PR TITLE
[2/2] Settings: Add per app controls for LP keyguard notifications

### DIFF
--- a/res/values/pa_strings.xml
+++ b/res/values/pa_strings.xml
@@ -54,4 +54,11 @@
 
     <!-- Gestures -->
     <string name="gesture_title">Gestures</string>
+
+    <!-- Per app controls for LP keyguard notifications -->
+    <string name="app_notification_show_on_keyguard_title">Show on lockscreen</string>
+    <string name="app_notification_show_on_keyguard_summary">Show notifications from this app on the lockscreen</string>
+    <string name="app_notification_no_ongoing_on_keyguard_title">Disable ongoing on lockscreen</string>
+    <string name="app_notification_no_ongoing_on_keyguard_summary">Never show ongoing notifications from this app on the lockscreen</string>
+
 </resources>

--- a/res/xml/app_notification_settings.xml
+++ b/res/xml/app_notification_settings.xml
@@ -26,6 +26,21 @@
             android:disableDependentsState="true"
             android:persistent="false" />
 
+    <!-- Keyguard options -->
+    <SwitchPreference
+            android:key="show_on_keyguard"
+            android:title="@string/app_notification_show_on_keyguard_title"
+            android:summary="@string/app_notification_show_on_keyguard_summary"
+            android:dependency="block"
+            android:persistent="false" />
+
+    <SwitchPreference
+            android:key="no_ongoing_on_keyguard"
+            android:title="@string/app_notification_no_ongoing_on_keyguard_title"
+            android:summary="@string/app_notification_no_ongoing_on_keyguard_summary"
+            android:dependency="show_on_keyguard"
+            android:persistent="false" />
+
     <!-- Priority -->
     <SwitchPreference
             android:key="priority"

--- a/src/com/android/settings/notification/AppNotificationSettings.java
+++ b/src/com/android/settings/notification/AppNotificationSettings.java
@@ -16,6 +16,7 @@
 
 package com.android.settings.notification;
 
+import android.app.Notification;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
@@ -51,6 +52,8 @@ public class AppNotificationSettings extends SettingsPreferenceFragment {
     private static final String KEY_BLOCK = "block";
     private static final String KEY_PRIORITY = "priority";
     private static final String KEY_SENSITIVE = "sensitive";
+    private static final String KEY_SHOW_ON_KEYGUARD = "show_on_keyguard";
+    private static final String KEY_NO_ONGOING_ON_KEYGUARD = "no_ongoing_on_keyguard";
 
     static final String EXTRA_HAS_SETTINGS_INTENT = "has_settings_intent";
     static final String EXTRA_SETTINGS_INTENT = "settings_intent";
@@ -61,6 +64,8 @@ public class AppNotificationSettings extends SettingsPreferenceFragment {
     private SwitchPreference mBlock;
     private SwitchPreference mPriority;
     private SwitchPreference mSensitive;
+    private SwitchPreference mShowOnKeyguard;
+    private SwitchPreference mShowNoOngoingOnKeyguard;
     private AppRow mAppRow;
     private boolean mCreated;
 
@@ -135,6 +140,8 @@ public class AppNotificationSettings extends SettingsPreferenceFragment {
         mBlock = (SwitchPreference) findPreference(KEY_BLOCK);
         mPriority = (SwitchPreference) findPreference(KEY_PRIORITY);
         mSensitive = (SwitchPreference) findPreference(KEY_SENSITIVE);
+        mShowOnKeyguard = (SwitchPreference) findPreference(KEY_SHOW_ON_KEYGUARD);
+        mShowNoOngoingOnKeyguard = (SwitchPreference) findPreference(KEY_NO_ONGOING_ON_KEYGUARD);
 
         final boolean secure = new LockPatternUtils(getActivity()).isSecure();
         final boolean enabled = getLockscreenNotificationsEnabled();
@@ -188,8 +195,50 @@ public class AppNotificationSettings extends SettingsPreferenceFragment {
             });
         }
 
+        int keyguard = mBackend.getShowNotificationForPackageOnKeyguard(pkg, uid);
+        mShowOnKeyguard.setChecked((keyguard & Notification.SHOW_ALL_NOTI_ON_KEYGUARD) != 0);
+        mShowNoOngoingOnKeyguard.setChecked(
+                (keyguard & Notification.SHOW_NO_ONGOING_NOTI_ON_KEYGUARD) != 0);
+
+        mShowOnKeyguard.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                final boolean showOnKeyguard = (Boolean) newValue;
+                int keyguard = mBackend.getShowNotificationForPackageOnKeyguard(pkg, uid);
+
+                if (showOnKeyguard && (keyguard & Notification.SHOW_ALL_NOTI_ON_KEYGUARD) == 0) {
+                    keyguard |= Notification.SHOW_ALL_NOTI_ON_KEYGUARD;
+                } else {
+                    keyguard &= ~Notification.SHOW_ALL_NOTI_ON_KEYGUARD;
+                }
+                return mBackend.setShowNotificationForPackageOnKeyguard(pkg, uid, keyguard);
+            }
+        });
+
+        mShowNoOngoingOnKeyguard.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                final boolean showNoOngoingOnKeyguard = (Boolean) newValue;
+                int keyguard = mBackend.getShowNotificationForPackageOnKeyguard(pkg, uid);
+                if (showNoOngoingOnKeyguard
+                        && (keyguard & Notification.SHOW_NO_ONGOING_NOTI_ON_KEYGUARD) == 0) {
+                    keyguard |= Notification.SHOW_NO_ONGOING_NOTI_ON_KEYGUARD;
+                } else {
+                    keyguard &= ~Notification.SHOW_NO_ONGOING_NOTI_ON_KEYGUARD;
+                }
+                return mBackend.setShowNotificationForPackageOnKeyguard(pkg, uid, keyguard);
+            }
+        });
+
         // Users cannot block notifications from system/signature packages
-        if (Utils.isSystemPackage(pm, info)) {
+        final boolean isSystemPkg = Utils.isSystemPackage(pm, info);
+
+        if (isSystemPkg || !getLockscreenNotificationsEnabled()) {
+            getPreferenceScreen().removePreference(mShowNoOngoingOnKeyguard);
+            getPreferenceScreen().removePreference(mShowOnKeyguard);
+        }
+
+        if (isSystemPkg) {
             getPreferenceScreen().removePreference(mBlock);
             mPriority.setDependency(null); // don't have it depend on a preference that's gone
         }

--- a/src/com/android/settings/notification/NotificationAppList.java
+++ b/src/com/android/settings/notification/NotificationAppList.java
@@ -590,5 +590,24 @@ public class NotificationAppList extends PinnedHeaderListFragment
                 return false;
             }
         }
+
+        public int getShowNotificationForPackageOnKeyguard(String pkg, int uid) {
+            try {
+                return sINM.getShowNotificationForPackageOnKeyguard(pkg, uid);
+            } catch (Exception e) {
+                Log.w(TAG, "Error calling NoMan", e);
+                return Notification.SHOW_ALL_NOTI_ON_KEYGUARD;
+            }
+        }
+
+        public boolean setShowNotificationForPackageOnKeyguard(String pkg, int uid, int status) {
+            try {
+                sINM.setShowNotificationForPackageOnKeyguard(pkg, uid, status);
+                return true;
+            } catch (Exception e) {
+                Log.w(TAG, "Error calling NoMan", e);
+                return false;
+            }
+        }
     }
 }


### PR DESCRIPTION
Nice done by google but the UX is a problem especially for ppl who are using a lot apps and just want
to see from important apps the notifications on the lockscreen.

This commit adds the ability to
- enable/disable per app the keyguard notification at all
- enable/disable per app ongoing notifications on the keyguard

We handle this over the app policy conf file like the other per app notification options

Change-Id: I2b7a2370f22d6976356ed558eb876d8cf1899f27
